### PR TITLE
Remove .gitconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,9 @@ Information dense, visually light
 ## Installation
 
 * ```git clone https://github.com/ProgramMax/dotfiles.git```
-* edit .gitconfig to your own identity
 * install i3, wget, and unzip
-* run font scripts
-* copy files from ./dotfiles to ~
 * [instructions for installing fonts](/documentation/font-installation.md)
+* copy files from ./dotfiles to ~
 
 ## Engage
 

--- a/dotfiles/.gitconfig
+++ b/dotfiles/.gitconfig
@@ -1,3 +1,0 @@
-[user]
-    name = Chris Blume
-    email = ProgramMax@gmail.com


### PR DESCRIPTION
It didn't make sense to require every user to remve my .gitconfig file.
Especially if I intend to initially get my dotfiles on a new machine via
SSH instead of HTTPS. I would have already set my git config by then.

This commit removes the .gitconfig file and updates README.md to reflect
this change.