### PR TITLE
Change status bar icons

### DIFF
--- a/dotfiles/.config/i3status/config
+++ b/dotfiles/.config/i3status/config
@@ -55,15 +55,15 @@ disk "/" {
 }
 
 wireless wls1 {
-	# format_up   = ": %quality on %essid, %bitrate %ip"
-	format_up   = ": %quality on %essid, %bitrate"
-	format_down = ": down"
+	# format_up   = "📶: %quality on %essid, %bitrate %ip"
+	format_up   = "📶: %quality on %essid, %bitrate"
+	format_down = "📶: down"
 }
 
 ethernet enp3s0 {
-	# format_up   = ": %ip (%speed)"
-	format_up   = ": %speed"
-	format_down = ": down"
+	# format_up   = "🖧: %ip (%speed)"
+	format_up   = "🖧: %speed"
+	format_down = "🖧: down"
 }
 
 run_watch DHCP {


### PR DESCRIPTION
The existing icons rely on a specially modified font. This step
adds complication and doesn't work in situations where the user
cannot install fonts.

This commit replaces the special font dependency with standard
emoji.