### PR TITLE
Replace special fonts with DejaVu Sans Mono

### DIFF
--- a/dotfiles/.Xdefaults
+++ b/dotfiles/.Xdefaults
@@ -8,9 +8,8 @@ xft.antialias: true
 xft.hinting:   true
 xft.hintstyle: hintsligiht
 
-!urxvt*font: xft:Source Code Pro:pixelsize=10:antialias=true:hinting=true,fixed:pixelsize:10
-!urxvt*letterSpace: -1
-urxvt*font: xft:Droid Sans Mono:pixelsize=10:antialias=true:hinting=true,fixed:pixelsize:10
+urxvt*font: xft:DejaVu Sans Mono:pixelsize=10:antialias=true:hinting=true,fixed:pixelsize:10
+
 
 urxvt*background: #2c2c2c
 urxvt*foreground: #9f9f9f

--- a/dotfiles/.i3/config
+++ b/dotfiles/.i3/config
@@ -12,19 +12,7 @@ bindsym $mod+b border toggle
 new_window pixel 1 px
 new_float normal 3 px
 
-# Font for window titles. Will also be used by the bar unless a different font
-# is used in the bar {} block below.
-# This font is widely installed, provides lots of unicode glyphs, right-to-left
-# text rendering and scalability on retina/hidpi displays (thanks to pango).
-#font pango:DejaVu Sans Mono 8
-# Before i3 v4.8, we used to recommend this one as the default:
-# font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-# The font above is very space-efficient, that is, it looks good, sharp and
-# clear in small sizes. However, its unicode glyph coverage is limited, the old
-# X core fonts rendering does not support right-to-left and this being a bitmap
-# font, it doesn’t scale on retina/hidpi displays.
-# font pango:Source code Pro for Powerline 10px
-font pango:Droid Sans Mono, Icons 12px
+font pango:DejaVu Sans Mono 12px
 
 # Use Mouse+$mod to drag floating windows to their wanted position
 floating_modifier $mod
@@ -188,9 +176,7 @@ bar {
 	workspace_buttons yes
 	tray_output       primary
 
-	#font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-	font pango:Source Code Pro for Powerline, FontAwesome, Icons 10px
-	#font pango:Droid Sans Mono, FontAwesome 10px
+	font pango:DejaVu Sans Mono 10px
 
 	colors {
 		background $bg

--- a/dotfiles/XTerm
+++ b/dotfiles/XTerm
@@ -2,10 +2,7 @@ XTerm*Background: #2c2c2e
 XTerm*Foreground: #9f9f9f
 XTerm*saveLines: 1000
 XTerm*geometry: +50+100
-!XTerm*faceName: Source Code Pro for Powerline:size=8, \
-!                fixed:size=8
-XTerm*faceName: Droid Sans Mono:size=10, fixed:size=10
-!URxvt.letterSpace: -1
+XTerm*faceName: DejaVu Sans Mono:size=10, fixed:size=10
 
 
 ! terminal colors


### PR DESCRIPTION
Previously, custom fonts were installed. This included a special
font which built icons into it. These custom fonts complicated
things and didn't work for users who could not install fonts.

This commit replaces those special fonts with a commonly available
font, DejaVu Sans Mono.