### PR TITLE
Remove font installation steps from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ Information dense, visually light
 ## Installation
 
 * ```git clone https://github.com/ProgramMax/dotfiles.git```
-* install i3, wget, and unzip
-* [instructions for installing fonts](/documentation/font-installation.md)
+* install i3
 * copy files from ./dotfiles to ~
 
 ## Engage


### PR DESCRIPTION
README.md had instructions for what needs to be installed prior
to running the font installation scripts. Since there are no longer
font installation scripts, these steps are incorrect.

This commit updates README.md to reflect the new instructions for
installing the dotfiles.